### PR TITLE
added 1.7.2-dev.json for use for the installer

### DIFF
--- a/json/1.7.2-dev.json
+++ b/json/1.7.2-dev.json
@@ -172,5 +172,5 @@
       }
     }
   ],
-  "mainClass": "net.minecraft.client.main.Main"
+  "mainClass": "net.minecraft.launchwrapper.Launch"
 }


### PR DESCRIPTION
this file will contain all libraries used by Minecraft and BlazeLoader in the MCP environment this will be used by the installer. this does not have to be compiled with BlazeLoader itself.
