### PR TITLE
Downgrade launchWrapper + added scala libs

### DIFF
--- a/json/BL-1.7.2-dev.json
+++ b/json/BL-1.7.2-dev.json
@@ -8,11 +8,17 @@
     {
       "name": "net.acomputerdog:BlazeLoader:1.7.2_dev"
     },
+    {
+      "name": "org.scala-lang:scala-library:2.10.2"
+    },
+    {
+      "name": "org.scala-lang:scala-compiler:2.10.2"
+    },
   	{
       "name": "org.ow2.asm:asm-debug-all:4.1"
     },
     {
-      "name": "net.minecraft:launchwrapper:1.9"
+      "name": "net.minecraft:launchwrapper:1.8"
     },
     {
       "name": "java3d:vecmath:1.3.1"

--- a/json/libraries.json
+++ b/json/libraries.json
@@ -1,12 +1,22 @@
 {
   "libraries": [
+	{
+      "name": "org.scala-lang:scala-library:2.10.2",
+      "autodownload": false,
+      "url": "http://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.10.2/scala-library-2.10.2.jar"
+    },
+	{
+      "name": "org.scala-lang:scala-compiler:2.10.2",
+      "autodownload": false,
+      "url": "http://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.10.2/scala-compiler-2.10.2.jar"
+    },
   	{
       "name": "org.ow2.asm:asm-debug-all:4.1",
       "autodownload": false,
       "url": "http://repo1.maven.org/maven2/org/ow2/asm/asm-debug-all/4.1/asm-debug-all-4.1.jar"
     },
     {
-      "name": "net.minecraft:launchwrapper:1.9",
+      "name": "net.minecraft:launchwrapper:1.8",
       "autodownload": false
     },
     {


### PR DESCRIPTION
Downgraded the launchwrapper to same version as forge so we don't need to have 2 versions of the launchwrapper in the MC installation. Also added the scala libs for mods written in scala, again used the same versions as forge does.
